### PR TITLE
Switch --measure-* from em to ch.

### DIFF
--- a/src/lib/typography.css
+++ b/src/lib/typography.css
@@ -65,9 +65,9 @@
   /**
    * Measures
    * Applied as max-width
-   * Results in ~45/~66/~80 character measures
+   * Results in 45/65/80 character measures
    */
-  --measure-narrow: 20em;
-  --measure-normal: 30em;
-  --measure-wide: 34em;
+  --measure-narrow: 45ch;
+  --measure-normal: 65ch;
+  --measure-wide: 80ch;
 }


### PR DESCRIPTION
I noticed that `em` values were chosen to get close to a certain number of characters within the width.

This PR proposes using the [`ch` unit](https://caniuse.com/ch-unit) in order to target those widths exactly.

I rounded 66 to the nearest 5.